### PR TITLE
fix: inline form-contact shortcode in layout (Hugo template syntax error)

### DIFF
--- a/ZeroHunger.ai/themes/zerohunger/layouts/index.html
+++ b/ZeroHunger.ai/themes/zerohunger/layouts/index.html
@@ -101,7 +101,21 @@
   </div>
 
   <div style="max-width:36rem;margin:0 auto">
-    {{< form-contact action="https://fabform.io/f/-xMvsgp" >}}
+    <form class="zh-form" accept-charset="UTF-8" action="https://fabform.io/f/-xMvsgp" method="POST" role="form">
+      <div class="zh-field">
+        <label class="zh-label" for="name">Name <span class="req" aria-hidden="true">*</span></label>
+        <input class="zh-input" type="text" id="name" name="name" required placeholder="Your name" aria-required="true">
+      </div>
+      <div class="zh-field">
+        <label class="zh-label" for="email">Email address <span class="req" aria-hidden="true">*</span></label>
+        <input class="zh-input" type="email" id="email" name="email" required placeholder="you@example.com" aria-required="true">
+      </div>
+      <div class="zh-field">
+        <label class="zh-label" for="message">Message</label>
+        <textarea class="zh-textarea" id="message" name="message" placeholder="Tell us about your challenge…"></textarea>
+      </div>
+      <button class="zh-btn zh-btn--primary" type="submit">Send message</button>
+    </form>
   </div>
 
   <div class="zh-section--tight" style="text-align:center">


### PR DESCRIPTION
## Summary

Hugo layouts cannot use shortcode syntax (`{{< >}}`). The `themes/zerohunger/layouts/index.html` had `{{< form-contact action="..." >}}` which caused `unexpected "<" in command` at build time.

Fix: inline the `form-contact` shortcode HTML directly into the layout template.

This is the third and final commit in the OPT-317 fix set for the hero + cookie banner issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)