### PR TITLE
fix: remove duplicate form/iframe from _index.md (page auto-scroll)

### DIFF
--- a/ZeroHunger.ai/content/en/_index.md
+++ b/ZeroHunger.ai/content/en/_index.md
@@ -12,14 +12,6 @@ cascade:
   featured_image: '../images/workshop.jpg'
 ---
 
-# Start Your Product Today!
-
-Accelerate your Impact with Software and AI.
-
-## What's Your Challenge?
-
-Use the form below to tell us how software or AI can help you or the people you work with. Or, book a meeting now to turn your idea into a product in the next development cycle.
-
 ## Together, We're a Great Team
 
 We'll give you the right people and tools. In just two months, you'll have a simple version of the product that makes your work better.
@@ -27,15 +19,3 @@ We'll give you the right people and tools. In just two months, you'll have a sim
 ## We Keep Making Things Better
 
 Once your product is working, we put all its revenue and available funding into making it better and keeping it running. Continue to guide the way, to ensure an increasingly useful application for your organization, projects and programmes.
-
-{{< form-contact action="https://fabform.io/f/-xMvsgp"  >}}
-
----
-
-# OR
-
----
-
-{{< rawhtml >}}
-<iframe src='https://outlook.office365.com/owa/calendar/Bookameeting@zerohunger.ai/bookings/' width='100%' height='1100' scrolling='yes' style='border:0'></iframe>
-{{< /rawhtml >}}


### PR DESCRIPTION
## Summary

The zerohunger theme's `index.html` already owns the contact form and booking calendar sections. The `_index.md` content was duplicating them via `{{< form-contact >}}` and `{{< rawhtml >}}<iframe>` shortcodes. This caused:
- Two contact forms on the page
- Two booking calendar iframes
- Page auto-scrolling to ~4600px on load (Outlook iframe focus event)

Fix: strip shortcodes from `_index.md`; keep only the body copy that the layout renders via `{{ .Content }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)