### PR TITLE
fix: add Blog to main navigation menu (OPT-323)

### DIFF
--- a/ZeroHunger.ai/content/en/post/_index.md
+++ b/ZeroHunger.ai/content/en/post/_index.md
@@ -2,6 +2,10 @@
 title: "Blog"
 date: 2023-02-02T17:16:43+01:00
 weight: 3
+menu:
+  main:
+    name: "Blog"
+    weight: 3
 ---
 <!-- 
 ## We are currently bootstrapping!


### PR DESCRIPTION
## Summary

Fixes the missing Blog link in the main navigation bar.

The `/post/` blog index exists and loads correctly, but the nav menu entry was absent because `post/_index.md` was missing the `menu.main` front matter block (present on all other nav pages such as Projects, Workshops, About).

- Added `menu: main: name: Blog / weight: 3` to `content/en/post/_index.md`
- Nav now shows: Launch Your Product · Projects · **Blog** · Workshops · Contribute · About

Closes OPT-323. Part of OPT-327 pre-merge cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)