### PR TITLE
feat: GDPR-compliant privacy policy (OPT-326)

### DIFF
--- a/ZeroHunger.ai/content/en/privacy.md
+++ b/ZeroHunger.ai/content/en/privacy.md
@@ -1,11 +1,181 @@
 ---
-title: Privacy policy
+title: "Privacy Policy"
+description: "Information on data protection pursuant to GDPR for users of our website."
 type: page
 omit_header_text: true
-#menu: 
-#  - main
+translationKey: "privacy"
 ---
 
-### Google Analytics
+## 1. Controller
 
-This website uses Google Analytics. However, we have taken all actions we can to limit the power of Google. We have configured Google Analytics to anonymize IP addresses, use SSL at all time and we have agreed a Data Processing Amendment with Google. These measures were taken from a derective of the CBP (Dutch Institute for Privacy Protection) from 2018 on how to legally use Google Analytics without explicit consent.
+The controller within the meaning of Art. 4(7) of the EU General Data Protection Regulation (GDPR) is:
+
+Zero Hunger AI UG (haftungsbeschränkt)
+Hublandplatz 1
+97074 Würzburg
+Germany
+
+**Commercial register:** HRB 16683, Amtsgericht Würzburg
+**Email:** info@zerohunger.ai
+
+If you have any questions about data protection, please contact us at the email address above.
+
+## 2. Overview of Data Processing
+
+We process personal data only to the extent necessary to provide a functional website, our content, and our services. We collect and use personal data only with your consent or where processing is permitted by law. The following sections describe the types, scope, and purposes of data processing on this website.
+
+## 3. Legal Bases for Processing (Art. 6 GDPR)
+
+We process your personal data on the following legal bases:
+
+- **Consent (Art. 6(1)(a) GDPR):** Where you have given consent for a specific processing purpose — for example, submitting a contact form or accepting analytics cookies. You may withdraw consent at any time with effect for the future.
+- **Contractual performance (Art. 6(1)(b) GDPR):** Where processing is necessary for the performance of a contract or pre-contractual measures — for example, responding to your booking request.
+- **Legitimate interests (Art. 6(1)(f) GDPR):** Where processing is necessary for our legitimate interests, provided your rights and freedoms do not override those interests — for example, ensuring the technical operation and security of our website, or analyzing aggregated usage patterns with privacy-friendly tools.
+
+## 4. Hosting and Server Log Files
+
+### 4.1 Hosting
+
+This website is hosted by a European hosting provider. When you visit our website, the hosting provider automatically collects and stores information in server log files that your browser transmits. This includes:
+
+- IP address (anonymized where technically feasible)
+- Date and time of the request
+- URL of the requested page
+- Referrer URL (the page from which ours was accessed)
+- Browser type and version
+- Operating system
+
+This data is processed on the basis of Art. 6(1)(f) GDPR. Our legitimate interest lies in the stable, secure provision and optimization of our website. Server log files are stored for up to 14 days and then automatically deleted, unless longer retention is required for security incident investigation.
+
+### 4.2 Content Delivery and External Resources
+
+Our website may load fonts, scripts, or stylesheets from external servers (e.g. Google Fonts, CDN providers). When your browser requests these resources, your IP address is transmitted to the respective provider. This processing is based on Art. 6(1)(f) GDPR — our legitimate interest in a uniform, optimized presentation of our website.
+
+## 5. Analytics
+
+### 5.1 Google Analytics 4 (GA4)
+
+This website uses Google Analytics 4 (Measurement ID: G-YDRBDSQ6P9), a web analytics service provided by Google Ireland Limited ("Google"). GA4 processes data including:
+
+- Pages visited and interaction events
+- Approximate location (derived from anonymized IP)
+- Device and browser information
+- Referral source
+
+**Consent requirement (TTDSG § 25):** Accessing information stored on your device (e.g. cookies) for analytics purposes requires your prior consent under § 25 of the German Telecommunications-Digital Services Data Protection Act (TTDSG). **GA4 is only activated after you provide explicit consent** via our cookie consent banner (Art. 6(1)(a) GDPR in conjunction with § 25 TTDSG). Without your consent, no GA4 tracking occurs.
+
+**US data transfer:** Google may transfer data to servers in the United States. We rely on the EU–US Data Privacy Framework and Google's Standard Contractual Clauses (Art. 46(2)(c) GDPR) to ensure an adequate level of data protection.
+
+**Opt-out:** You may withdraw your consent at any time through the cookie settings on our website. Additionally, you can prevent GA4 data collection by installing the [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout).
+
+For more information, see Google's [Privacy Policy](https://policies.google.com/privacy) and [Analytics Data Processing Terms](https://business.safety.google/adsprocessorterms/).
+
+## 6. Cookies
+
+### 6.1 What Are Cookies
+
+Cookies are small text files stored on your device by your browser. They serve various purposes, from ensuring website functionality to measuring usage patterns.
+
+### 6.2 Cookies on This Website
+
+**Strictly necessary cookies:** We may use technically necessary cookies (e.g. session management, consent preferences). These do not require consent as they are essential for the website to function (Art. 6(1)(f) GDPR).
+
+**Analytics cookies (non-essential):** Google Analytics 4 sets cookies (e.g. `_ga`, `_ga_G-YDRBDSQ6P9`) to distinguish users and sessions. These cookies are only set after you give explicit consent via our cookie consent banner (Art. 6(1)(a) GDPR in conjunction with § 25 TTDSG). Without consent, no analytics cookies are placed on your device.
+
+### 6.3 Managing Cookies
+
+You can configure your browser to reject cookies or to alert you when cookies are being set. Please note that some website features may not function properly without technically necessary cookies. You can also withdraw consent for optional cookies at any time through the cookie settings on our website.
+
+## 7. Contact and Booking Forms
+
+### 7.1 Contact and Lead Forms
+
+When you submit a form on our website (e.g. lead magnet download, consultation request), we collect the information you provide:
+
+- Name
+- Email address
+- Company name
+- Industry
+
+This data is processed for the purpose of responding to your inquiry and providing the requested information. The legal basis is Art. 6(1)(a) GDPR (your consent via the form's consent checkbox) and Art. 6(1)(b) GDPR (pre-contractual measures). We store this data until the purpose of processing has been fulfilled or you request deletion.
+
+### 7.2 Booking (Microsoft Outlook)
+
+Our booking page embeds a Microsoft Outlook scheduling widget. When you use this widget, your data (name, email, booking details) is processed by Microsoft Corporation. This processing is based on Art. 6(1)(b) GDPR (pre-contractual measures — scheduling a consultation). For details, see [Microsoft's Privacy Statement](https://privacy.microsoft.com/privacystatement).
+
+### 7.3 Email Communication
+
+When you contact us by email, the data you provide (email address, name, message content) is stored for the purpose of processing your inquiry. We delete this data after your request has been fully handled, unless statutory retention obligations apply.
+
+Legal basis: Art. 6(1)(b) GDPR for contract-related inquiries; Art. 6(1)(f) GDPR for all other inquiries (legitimate interest in responding to communications).
+
+## 8. Third-Party Services
+
+### 8.1 Calendly
+
+We use Calendly for appointment scheduling. When you book through Calendly, your name, email, and scheduling data are processed by Calendly LLC. Calendly may transfer data to the United States; adequate safeguards are ensured via Standard Contractual Clauses. Legal basis: Art. 6(1)(b) GDPR (pre-contractual measures). See [Calendly's Privacy Notice](https://calendly.com/privacy).
+
+## 9. Data Subject Rights (Art. 15–21 GDPR)
+
+Under the GDPR, you have the following rights with respect to your personal data:
+
+### 9.1 Right of Access (Art. 15 GDPR)
+
+You have the right to obtain confirmation as to whether we process personal data concerning you. If so, you have the right to access this data and receive information about the processing purposes, categories of data, recipients, retention periods, and your further rights.
+
+### 9.2 Right to Rectification (Art. 16 GDPR)
+
+You have the right to request the correction of inaccurate personal data concerning you without undue delay. You also have the right to have incomplete personal data completed.
+
+### 9.3 Right to Erasure (Art. 17 GDPR)
+
+You have the right to request the erasure of your personal data without undue delay where one of the following grounds applies: the data is no longer necessary for the purposes for which it was collected; you withdraw consent; you object to the processing; the data has been unlawfully processed; or erasure is required by law.
+
+### 9.4 Right to Restriction of Processing (Art. 18 GDPR)
+
+You have the right to request restriction of processing where: the accuracy of the data is contested; the processing is unlawful but you oppose erasure; we no longer need the data but you require it for legal claims; or you have objected to processing pending verification.
+
+### 9.5 Right to Data Portability (Art. 20 GDPR)
+
+You have the right to receive the personal data you have provided to us in a structured, commonly used, and machine-readable format. You also have the right to request that we transmit this data directly to another controller, where technically feasible.
+
+### 9.6 Right to Object (Art. 21 GDPR)
+
+**You have the right to object at any time to the processing of your personal data based on Art. 6(1)(f) GDPR (legitimate interests), on grounds relating to your particular situation. If you object, we will cease processing unless we demonstrate compelling legitimate grounds that override your interests, rights, and freedoms, or the processing serves the establishment, exercise, or defense of legal claims.**
+
+### 9.7 Right to Withdraw Consent (Art. 7(3) GDPR)
+
+Where processing is based on your consent, you have the right to withdraw that consent at any time. Withdrawal does not affect the lawfulness of processing carried out before the withdrawal.
+
+### 9.8 Right to Lodge a Complaint (Art. 77 GDPR)
+
+You have the right to lodge a complaint with a supervisory authority if you believe that the processing of your personal data infringes the GDPR.
+
+To exercise any of these rights, please contact us at: **info@zerohunger.ai**
+
+## 10. Supervisory Authority
+
+The competent supervisory authority for data protection matters is:
+
+Bayerisches Landesamt für Datenschutzaufsicht (BayLDA)
+Promenade 18
+91522 Ansbach
+Germany
+
+**Phone:** +49 981 180093-0
+**Email:** poststelle@lda.bayern.de
+**Website:** [https://www.lda.bayern.de](https://www.lda.bayern.de)
+
+## 11. Data Retention
+
+We retain personal data only for as long as necessary to fulfill the purpose for which it was collected, or as required by statutory retention obligations (e.g. commercial or tax law retention periods of 6 to 10 years under German law). Once the purpose has been fulfilled and retention obligations have expired, the data is deleted or anonymized.
+
+## 12. Data Security
+
+This website is served exclusively over encrypted HTTPS connections (SSL/TLS). We use industry-standard technical and organizational measures to protect your personal data against unauthorized access, loss, destruction, or alteration. These measures are regularly reviewed and updated in line with technological developments.
+
+## 13. Changes to This Privacy Policy
+
+We reserve the right to update this privacy policy to reflect changes in our data processing practices or legal requirements. The current version is always available on this page.
+
+**Last updated:** May 2026


### PR DESCRIPTION
## Summary

Replaces the 3-sentence stub privacy policy with a full GDPR-compliant version written by the Content Writer for OPT-326.

### What changed
- `content/en/privacy.md` — complete rewrite (~180 lines)
- Controller: Zero Hunger AI UG, Hublandplatz 1, 97074 Würzburg, HRB 16683
- Legal bases (Art. 6 GDPR)
- Hosting + server logs (14-day retention)
- GA4 with Consent Mode v2, TTDSG § 25 consent requirement, EU–US DPF safeguards
- Cookie categories (essential vs non-essential analytics)
- Booking forms: Outlook + Calendly
- Data subject rights (Art. 15–21 GDPR)
- Supervisory authority: BayLDA, Ansbach (Bavaria)
- Data retention, SSL/TLS security

### Decisions made vs original draft
- **Removed Plausible Analytics section**: the site does not deploy Plausible — only GA4 (confirmed via `head.html`). Keeping it would be inaccurate.
- **Kept GA4 section**: GA4 is active via `config.toml googleAnalytics = "G-YDRBDSQ6P9"` and Consent Mode v2 denies by default.
- **Removed Formspree reference**: Formspree endpoint is unconfigured (`endpoint: ""`); referencing it as active would be inaccurate.

### Deferred
- **German Datenschutzerklärung** — Content Writer wrote `de/datenschutz/_index.md` but the site has no `[languages.de]` Hugo config. German version is a separate task requiring multilingual setup.
- **Legal review recommended** before production release.

Closes OPT-326. Part of OPT-327 pre-merge cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)