### PR TITLE
feat: wire up workshops article on workshops page (OPT-328)

### DIFF
--- a/ZeroHunger.ai/content/en/workshops.md
+++ b/ZeroHunger.ai/content/en/workshops.md
@@ -2,29 +2,186 @@
 title: Workshops
 featured_image: '../images/workshop.jpg'
 omit_header_text: true
-description: Join our open workshops!
+description: "Hands-on workshop formats for AI strategy, digital capacity building, and organizational development — proven across engagements in Africa, Latin America, and Europe."
 type: page
 menu:
   main:
     name: "Workshops"
     weight: 3
-
 ---
 
-# Open Workshops to Accelerate your Impact
+## Key Takeaways
 
-We are offering workshops to tech SMEs who are applicable to get support from the GIZ special initiative "Invest for Jobs" on behalf of the Federal Ministry for Economic Cooperation and Development.
+- Workshops are most effective when structured around a real problem the organization is currently facing, not generic training content.
+- Every workshop format below has been delivered in at least one real engagement — Honduras, Ethiopia, or Germany — with documented outcomes.
+- The strongest results come from combining on-site intensive workshops with remote preparation and follow-up support over weeks or months.
+- Workshop success depends more on organizational readiness and leadership commitment than on the facilitator or methodology used.
+- For international development contexts, local ownership of workshop outcomes is non-negotiable — external consultants advise and accelerate, they do not implement.
 
-Some workshops have already been planned, more to come...
+## Why Organizations Need Structured Workshops
 
-|   |                                                   |               |        |
-| ----- | ------------------------------------------------------ | ------------------ | ----------------- |
-| 10.08.   | Product Validation                                     | Product Management | Georg Warth       |
-| 15.08.   | User-Centric Design                                    | Product Management | Georg Warth       |
-| 17.08.   | Aligning businesses through purpose, values & strategy | Strategy           | Markus Matiaschek |
+Most AI and digital transformation projects fail not because the technology does not work, but because the organization is not aligned on what to build, who owns it, or how to sustain it. Workshops address this by creating structured environments where leadership teams, technical staff, and stakeholders confront these questions together — before committing resources to implementation.
 
-## Fill out the form below to upskill your business!
+A well-designed workshop compresses weeks of misaligned email chains and unclear decision-making into focused sessions where the right people are in the room, the right questions are on the table, and the outcome is a concrete plan rather than a vague agreement to "explore further."
 
-{{< rawhtml >}}
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSf2bmzzhYWtFEMxnu11QnJmEvF8cZewW9LGZEhYD9cUUd0TiQ/viewform?embedded=true" width="640" height="3131" frameborder="0" marginheight="0" marginwidth="0">Wird geladen…</iframe>
-{{< /rawhtml >}}
+This is not theoretical. Over the past three years, we have delivered workshops across three continents — from chamber of commerce networks in Honduras to tech startup cohorts in Ethiopia to NGO innovation teams in Germany — and the pattern holds: organizations that invest in structured alignment before building consistently outperform those that skip straight to implementation.
+
+## Workshop Formats We Deliver
+
+### 1. AI Use Case Discovery Workshop
+
+**Duration:** 1-2 days
+**Audience:** C-level, department heads, innovation leads
+**Outcome:** Prioritized list of AI use cases with feasibility assessment and implementation roadmap
+
+This workshop helps organizations identify where AI can create the most value in their specific context. Rather than presenting generic AI capabilities, we work backwards from the organization's actual bottlenecks, data assets, and strategic goals to surface use cases that are both high-impact and technically feasible.
+
+The process uses structured exercises — including stakeholder interviews, process mapping, and a scoring matrix for impact versus effort — to move from "AI could do anything" to "these three use cases are worth pursuing in the next quarter."
+
+**When to use it:** When leadership knows they should be using AI but has not identified specific, actionable opportunities.
+
+### 2. Digital Capacity Building Program
+
+**Duration:** 2-4 months (remote preparation + on-site intensive + remote follow-up)
+**Audience:** Technical staff, platform administrators, organizational leadership
+**Outcome:** Staff independently capable of managing and developing digital platforms
+
+This is not a one-off training session. It is a structured engagement that begins with a remote assessment phase, concentrates hands-on training into an intensive on-site workshop week, and continues with remote support to ensure skills transfer is sustained.
+
+**How it worked in practice — Honduras, 2024:**
+
+In February through April 2024, we delivered a digital capacity building program for five Honduran chambers of commerce building vocational training and job placement services. The client was FEDECAMARA — a network of 47 member chambers representing approximately 20,000 enterprises across 17 departments — working with bbw International and funded through Germany's BMZ via sequa.
+
+The engagement began with remote analysis of two existing digital platforms: a comprehensive security audit, performance review, and usability assessment. This was followed by weekly remote workshops over four weeks covering IT security, platform architecture, and SEO strategy. The program culminated in a five-day on-site workshop week in Tegucigalpa (April 15-19, 2024) covering:
+
+- Platform administration and operational handover
+- Data security and privacy practices
+- UX improvement and usability testing
+- System integration planning across the chamber network
+- Digital process documentation for sustainable operations
+
+Chamber staff were trained to independently manage and develop their digital platforms for job matching and skills training. The project also included consulting on the handover of platform operations from the originating chamber (CCIT Tegucigalpa) to FEDECAMARA as national operator.
+
+**Result:** The platform had already demonstrated significant traction — 3,442 job vacancies processed, over 27,000 CVs sent to employers, and 298 people placed in jobs in one year, with 92% client satisfaction. Our role was to prepare the technical and organizational foundation for scaling this from one city to 43 chambers nationwide.
+
+**Key lesson:** Technology is the easy part. The real challenge was organizational — getting 43 independent chambers, each with their own culture, capacity, and political dynamics, to adopt a shared digital infrastructure. The workshop week addressed this by bringing stakeholders into the same room and working through governance questions that remote calls could not resolve. [Read the full Honduras project story.](/projects/honduras/)
+
+### 3. Tech SME Acceleration Sprint
+
+**Duration:** 10 days on-site
+**Audience:** Startup founders, tech company leadership, product managers
+**Outcome:** Individual company assessments, strategic recommendations, and follow-up action plans
+
+An intensive acceleration format designed for cohorts of 5-15 tech companies at a similar stage. Each company receives individual half-day to full-day sessions tailored to their specific challenges, combined with group workshops on shared topics like lean methodology, product ownership, and go-to-market strategy.
+
+**How it worked in practice — Ethiopia, June 2023:**
+
+We led a 10-day acceleration sprint in Addis Ababa for Ethiopian tech companies participating in the sequa/GIZ acceleration programme (Project ET-1013). The cohort included companies across e-commerce, fintech, HR tech, education technology, and logistics — over 10 companies ranging from early-stage startups to established firms with 50+ employees.
+
+The sprint combined individual company sessions with group workshops:
+
+- **Strategy workshops** for companies that needed to narrow their focus — one company was running 18 separate products, far too many for its team to execute well on any of them
+- **Product ownership training** to help founders prioritize features, manage backlogs, and make data-informed build decisions
+- **User-centric design workshops** shifting companies from building what they assumed users wanted toward testing assumptions with real people
+- **OKR workshops** giving teams a practical framework for aligning around measurable outcomes rather than activity-based goals
+- **Software development process analysis** for companies whose engineering teams struggled with delivery cadence, quality, and coordination
+
+Each company received a needs assessment, SWOT analysis, strategic recommendations, and follow-up action plan. The program identified a pattern common in emerging-market tech ecosystems: the strongest companies had abundant potential but struggled with execution discipline and focus. This led to targeted coaching on prioritization and follow-through.
+
+**Result:** The acceleration sprint was part of a broader engagement spanning three field visits to Addis Ababa over 18 months (March 2023, June 2023, May 2024). This repeated-visit model proved more effective than a single longer engagement: companies had time to implement changes between visits, and we could assess what actually stuck versus what was just enthusiasm in the moment.
+
+**Key lesson:** Start with strategy, not code. The most impactful interventions were not technical — they were strategic. Helping a company with 18 products understand that it needed to focus on three was worth more than any amount of code review. [Read the full Ethiopia project story.](/projects/ethiopia/)
+
+### 4. Organizational Training and Talent Development Advisory
+
+**Duration:** 6-12 months (embedded advisory with on-site workshop phases)
+**Audience:** HR leadership, engineering management, C-level
+**Outcome:** Redesigned talent pipeline, career development frameworks, agile process documentation
+
+A long-term embedded advisory format for organizations facing growth bottlenecks related to talent, team structure, or organizational processes. The engagement combines on-site workshop phases with continuous remote advisory support.
+
+**How it worked in practice — Ethiopia, 2024-2025:**
+
+We served as Training Advisor to a large Ethiopian technology company facing a talent experience bottleneck that prevented it from scaling teams and onboarding new clients. The company had approximately 70 software professionals and operated a TechUp Bootcamp that had a placement rate of just 15% — 3 out of 20 candidates hired, all of whom were already highly qualified before entering the program. The engagement was contracted through sequa gGmbH under the ETH-1013-SME program for 20 working days over 10 months (July 2024 - April 2025).
+
+**Phase 1 — Leadership Alignment (August 2024):** On-site workshops in Addis Ababa covering strategy alignment, KPI development, and strategic HR planning. Key findings: the bootcamp conflated assessment, onboarding, and upskilling into a single program, diluting the effectiveness of each. Senior staff held multiple roles simultaneously, creating bottlenecks and preventing effective delegation.
+
+**Phase 2 — Talent Pipeline Redesign (September 2024):** Collaborative workshops on talent sourcing, team maturity assessment, career path design, and mentorship program improvement. We introduced a three-stage talent pipeline replacing the monolithic bootcamp: a focused Assessment Center, streamlined Onboarding process, and a self-organized Upskilling and Placement Pool Team of up to 9 members combining new talent and benched employees.
+
+**Phase 3 — Growth Strategy and Continuous Support (October 2024 - March 2025):** Bi-weekly remote check-ins, monthly leadership reviews, and a final on-site workshop presenting results and growth recommendations. OKRs were collaboratively developed targeting 20 graduates onboarded by January 2025 and a customer NPS improvement of 10 points by March 2025.
+
+**Result:** The engagement produced a redesigned bootcamp curriculum (4-6 week agile-based program), documented upskilling process aligned with the company's ISO 9001 certification, an OKR framework, staff growth projections modeling a path from 70 to 202 software professionals by 2027/28, and strategic recommendations covering talent development, bench management, and organizational agility.
+
+**Key lesson:** Embedded advisory requires internal ownership. An external consultant with 20 working days cannot drive organizational change alone. The advisory must design frameworks and create urgency, but the partner organization must provide active project leadership, stakeholder access, and willingness to experiment with new approaches.
+
+### 5. Innovation and Strategy Workshop
+
+**Duration:** 1-2 days
+**Audience:** Leadership teams, department heads, innovation managers
+**Outcome:** Prioritized challenge map, solution concepts, and 3-month action plan
+
+A structured innovation workshop using design thinking and liberating structures methodologies. Participants systematically analyze their organization's most important challenges, reframe them as opportunities, and develop solution concepts that can be prototyped and tested within months.
+
+The format combines individual reflection, small-group problem-solving, and large-group synthesis to ensure that every participant contributes and that outcomes represent genuine organizational alignment, not just the loudest voice in the room.
+
+**Topics we have facilitated in this format:**
+- Aligning businesses and teams for growth (vision, strategy, governance)
+- AI opportunity identification for social impact organizations
+- Digital transformation roadmapping for institutional networks
+- Product vs. project management in development cooperation contexts
+
+**When to use it:** When an organization needs to move from "we know we need to change" to "here is exactly what we will do in the next 90 days."
+
+## Common Pitfalls
+
+**Sending the wrong people.** Workshops that require strategic decisions need decision-makers in the room. Sending only junior staff to a strategy workshop wastes everyone's time and produces recommendations that die in the next management meeting.
+
+**Treating workshops as events, not processes.** A two-day workshop without preparation or follow-up is a team-building exercise, not a transformation tool. The most effective workshops are embedded in longer engagements with remote preparation, on-site intensive work, and structured follow-up.
+
+**Optimizing for comfort over confrontation.** The most valuable workshop moments are often uncomfortable — when a leadership team admits they have been building the wrong product, or when a founder realizes 18 product lines need to become three. Facilitators who avoid these moments deliver polished slide decks and zero organizational change.
+
+**Confusing agile vocabulary with agile practice.** Many organizations adopt Scrum terminology without understanding the purpose of retrospectives, sprint reviews, and timeboxing. Leadership must deeply engage with and champion the methodology before it cascades through the organization.
+
+**Ignoring local context.** In international development settings, workshop formats designed for Silicon Valley startups do not translate directly. Smartphone and data costs, cultural communication norms, institutional hierarchies, and the realities of grant-funded timelines all shape how workshops need to be designed and facilitated.
+
+## Who These Workshops Are For
+
+**Development organizations and their partners** implementing digital transformation, capacity building, or technology acceleration programs. Our workshop formats are designed for the realities of grant-funded timelines, multi-stakeholder governance, and the imperative of local ownership.
+
+**Technology companies facing growth bottlenecks** in talent, process, or product strategy. Whether you are a 10-person startup trying to find product-market fit or a 70-person company struggling to scale your teams, structured workshops compress months of unfocused effort into days of aligned action.
+
+**Chambers of commerce and institutional networks** modernizing their member services through digital platforms. Our experience with multi-chamber platform governance in Honduras directly applies to any federated organization trying to build shared digital infrastructure.
+
+**NGOs and social enterprises** seeking to integrate AI and technology into their operations. Innovation workshops help these organizations move beyond "we should use AI" to concrete, prioritized use cases grounded in their actual data, capacity, and mission.
+
+## Frequently Asked Questions
+
+### How long does a typical workshop engagement last?
+
+It depends on the format. A standalone innovation workshop runs 1-2 days. A digital capacity building program typically spans 2-4 months including remote preparation and follow-up. An embedded training advisory can run 6-12 months. The on-site intensive component — where the highest-impact work happens — is usually 3-10 days.
+
+### Do you deliver workshops remotely?
+
+Yes, but with conditions. Remote workshops work well for preparation phases, follow-up support, and knowledge transfer sessions. For strategic alignment, organizational development, and stakeholder consensus-building, on-site delivery produces significantly better outcomes. Our standard model combines both: remote preparation, on-site intensive, remote follow-up.
+
+### What industries do you work in?
+
+Our workshop experience spans international development, technology, BPO, institutional networks (chambers of commerce), and NGOs. The methodologies — design thinking, lean, agile, OKRs — are industry-agnostic. What varies is the facilitation style, examples, and organizational context we bring to each sector.
+
+### How do you measure workshop success?
+
+We define success metrics with the client before the engagement. For capacity building programs, this means staff demonstrating independent capability post-workshop. For acceleration sprints, it means companies executing on their action plans between visits. For organizational development, it means measurable improvements in KPIs like placement rates, team growth, or customer satisfaction within 6-12 months.
+
+### Can workshops be delivered in languages other than English?
+
+Yes. We deliver workshops in English and German. For engagements in Spanish-speaking countries (Honduras, Latin America), we work with bilingual teams and produce documentation in the client's working language.
+
+### What is the typical investment for a workshop engagement?
+
+Workshop pricing depends on format, duration, location, and scope. Standalone 1-2 day workshops start at a different price point than 10-month embedded advisory programs. Contact us for a tailored proposal based on your specific situation and goals.
+
+## Start a Conversation
+
+Whether you need a focused two-day strategy workshop or a multi-month capacity building program, we design every engagement around your specific challenge, context, and timeline.
+
+[Book a meeting](https://outlook.office365.com/owa/calendar/Bookameeting@zerohunger.ai/bookings/) to discuss which workshop format fits your situation, or [reach out through our contact form](/#contact) to tell us what you are working on.


### PR DESCRIPTION
## Summary

- Replaces the old workshops planning table with the full 2,500-word workshops article from `geo/articles/workshops.md`
- Covers 5 workshop formats, 3 detailed case studies (Honduras, Ethiopia acceleration sprint, Ethiopia talent advisory), common pitfalls, FAQ, and target audience sections
- All 5 `[INTERNAL_LINK: ...]` markers resolved: Honduras → `/projects/honduras/`, Ethiopia → `/projects/ethiopia/`, three others removed (no target pages exist yet)
- Description meta updated to match article SEO keywords
- Booking CTA preserved via article's "Start a Conversation" section linking to the Office 365 booking calendar and contact form

## Test plan

- [ ] Workshops page renders full article content on dev.zerohunger.ai
- [ ] Case study links to `/projects/honduras/` and `/projects/ethiopia/` work correctly
- [ ] Page displays properly on mobile and desktop viewports
- [ ] No `[INTERNAL_LINK: ...]` markers appear in rendered output
- [ ] Booking CTA ("Book a meeting" / contact form) visible at page bottom
- [ ] Navigation "Workshops" menu item still active

🤖 Generated with [Claude Code](https://claude.com/claude-code)