### PR TITLE
fix(OPT-325): remove FabForm, homepage contact → MS Bookings only

### DIFF
--- a/ZeroHunger.ai/content/en/contact.md
+++ b/ZeroHunger.ai/content/en/contact.md
@@ -1,12 +1,5 @@
 ---
-title: Received!
-featured_image: '../images/contact.jpg'
-omit_header_text: true
-description: We'd love to hear from you
-type: page
-
+title: Contact
+type: redirect
+redirect_url: "/#contact"
 ---
-
-## Thank you for your message.
-
-We will get back to you as soon as possible.

--- a/ZeroHunger.ai/layouts/redirect/single.html
+++ b/ZeroHunger.ai/layouts/redirect/single.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+<script>window.location.replace("{{ .Params.redirect_url }}");</script>
+<noscript>
+  <p style="text-align:center;padding:4rem 1rem">
+    Redirecting… <a href="{{ .Params.redirect_url }}">click here if you are not redirected automatically</a>
+  </p>
+</noscript>
+{{ end }}

--- a/ZeroHunger.ai/themes/zerohunger/layouts/index.html
+++ b/ZeroHunger.ai/themes/zerohunger/layouts/index.html
@@ -22,7 +22,7 @@
     <h1>{{ .Title }}</h1>
     {{ with .Description }}<p class="dek">{{ . }}</p>{{ end }}
     <div style="margin-top:2rem;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap">
-      <a href="#contact" class="zh-btn zh-btn--primary">Start Your Project</a>
+      <a href="#contact" class="zh-btn zh-btn--primary">Book a Meeting</a>
       <a href="/projects/" class="zh-btn zh-btn--ghost" style="color:#fff;border-color:#fff">Our Projects</a>
     </div>
   </div>
@@ -96,33 +96,11 @@
 {{/* ── CONTACT ──────────────────────────────────────────────────────── */}}
 <section id="contact" class="zh-section zh-container" aria-labelledby="contact-heading">
   <div class="zh-prose zh-prose--center" style="margin-bottom:var(--zh-space-4)">
-    <h2 id="contact-heading">What's Your Challenge?</h2>
-    <p>Use the form below to tell us how software or AI can help you or the people you work with. Or, book a meeting now to turn your idea into a product in the next development cycle.</p>
+    <h2 id="contact-heading">Book a Meeting</h2>
+    <p>Pick a time that works for you and tell us about your challenge. We will get back to you with a concrete proposal for the next development cycle.</p>
   </div>
 
-  <div style="max-width:36rem;margin:0 auto">
-    <form class="zh-form" accept-charset="UTF-8" action="https://fabform.io/f/-xMvsgp" method="POST" role="form">
-      <div class="zh-field">
-        <label class="zh-label" for="name">Name <span class="req" aria-hidden="true">*</span></label>
-        <input class="zh-input" type="text" id="name" name="name" required placeholder="Your name" aria-required="true">
-      </div>
-      <div class="zh-field">
-        <label class="zh-label" for="email">Email address <span class="req" aria-hidden="true">*</span></label>
-        <input class="zh-input" type="email" id="email" name="email" required placeholder="you@example.com" aria-required="true">
-      </div>
-      <div class="zh-field">
-        <label class="zh-label" for="message">Message</label>
-        <textarea class="zh-textarea" id="message" name="message" placeholder="Tell us about your challenge…"></textarea>
-      </div>
-      <button class="zh-btn zh-btn--primary" type="submit">Send message</button>
-    </form>
-  </div>
-
-  <div class="zh-section--tight" style="text-align:center">
-    <p class="zh-or">OR</p>
-  </div>
-
-  <div id="zh-booking-wrap" style="max-width:900px;margin:0 auto;min-height:200px">
+  <div id="zh-booking-wrap" style="max-width:900px;margin:0 auto;min-height:400px">
     <div id="zh-booking-placeholder" style="text-align:center;padding:3rem 1rem;border:1px solid var(--zh-border);border-radius:var(--zh-radius-2)">
       <p style="margin:0 0 1rem;font-size:var(--zh-fs-f5);color:var(--zh-fg-muted)">Book a 30-minute meeting with us</p>
       <button onclick="zhLoadBooking()" class="zh-btn zh-btn--primary">Open booking calendar</button>
@@ -134,7 +112,22 @@
   function zhLoadBooking() {
     var wrap = document.getElementById('zh-booking-wrap');
     wrap.innerHTML = '<iframe src="https://outlook.office365.com/owa/calendar/Bookameeting@zerohunger.ai/bookings/" width="100%" height="700" scrolling="yes" title="Book a meeting" style="border:0;border-radius:var(--zh-radius-2);display:block"></iframe>';
+    wrap.style.minHeight = '700px';
   }
+  // Auto-load the booking calendar when the section scrolls into view
+  (function () {
+    var loaded = false;
+    var section = document.getElementById('contact');
+    if (!section || !('IntersectionObserver' in window)) return;
+    var observer = new IntersectionObserver(function (entries) {
+      if (!loaded && entries[0].isIntersecting) {
+        loaded = true;
+        zhLoadBooking();
+        observer.disconnect();
+      }
+    }, { threshold: 0.1 });
+    observer.observe(section);
+  })();
 </script>
 
 {{ end }}

--- a/ZeroHunger.ai/themes/zerohunger/layouts/partials/head.html
+++ b/ZeroHunger.ai/themes/zerohunger/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} — {{ .Site.Title }}{{ end }}</title>
+{{ if eq .Type "redirect" }}<meta http-equiv="refresh" content="0; url={{ .Params.redirect_url }}">{{ end }}
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
 {{ with .Site.Params.googleAnalytics }}<meta name="google-site-verification" content="">
 


### PR DESCRIPTION
## Summary

FabForm.io is no longer active. This removes the contact form entirely and replaces the section with the Microsoft Bookings calendar embed as the sole contact method.

## Changes

- **Removed**: FabForm `<form>` and all fields (name, email, message, submit button)
- **Updated heading**: "What's Your Challenge?" → "Book a Meeting"
- **Updated hero CTA**: "Start Your Project" → "Book a Meeting"
- **MS Bookings**: now auto-loads via `IntersectionObserver` when the `#contact` section scrolls into view (no manual button click required)
- **`/contact/` redirect**: fixed — `type:redirect` page now redirects to `/#contact` via `<meta http-equiv="refresh">` + JS

## Supersedes

- PR #12 (`feat/playwright-e2e-opt325`) — close in favour of this PR; the contact redirect fix is included here
- The `_redirect` FabForm field added in #12 is moot since FabForm is removed

## Build verified

Hugo: 38 pages, no errors. `public/index.html` contains no `fabform` reference. `public/contact/index.html` has `meta http-equiv=refresh content="0; url=/#contact"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)