### PR TITLE
fix(OPT-321): restore workshop.jpg hero on homepage and about page

### DIFF
--- a/ZeroHunger.ai/content/en/about/index.md
+++ b/ZeroHunger.ai/content/en/about/index.md
@@ -1,7 +1,7 @@
 ---
 title: "About"
 description: "Our mission is to contribute with Free Software and AI to the United Nations Sustainable Development Goals"
-featured_image: '../images/software_and_AI_solving_world_hunger.jpg'
+featured_image: '/images/workshop.jpg'
 menu:
   main:
     weight: 9

--- a/ZeroHunger.ai/themes/zerohunger/layouts/_default/single.html
+++ b/ZeroHunger.ai/themes/zerohunger/layouts/_default/single.html
@@ -1,8 +1,27 @@
 {{ define "main" }}
+{{ $featImg := .Params.featured_image }}
+{{ $isStaticPath := and $featImg (strings.HasPrefix $featImg "/") }}
+{{ if $isStaticPath }}
+<section class="zh-hero" style="background-image:url('{{ $featImg }}')">
+  <picture style="position:absolute;inset:0;z-index:0">
+    <img src="{{ $featImg }}" alt="{{ .Title }}"
+         style="width:100%;height:100%;object-fit:cover;display:block" loading="eager">
+  </picture>
+  <div class="zh-hero__inner">
+    <h1>{{ .Title }}</h1>
+    {{ with .Description }}<p class="dek">{{ . }}</p>{{ end }}
+  </div>
+</section>
 <article class="zh-container zh-section">
   <div class="zh-prose">
-    {{ if .Params.featured_image }}
-    {{ $img := resources.Get .Params.featured_image }}
+    {{ .Content }}
+  </div>
+</article>
+{{ else }}
+<article class="zh-container zh-section">
+  <div class="zh-prose">
+    {{ if $featImg }}
+    {{ $img := resources.Get $featImg }}
     {{ if $img }}
     {{ $img800 := $img.Resize "800x webp" }}
     {{ $imgFallback := $img.Resize "800x jpg" }}
@@ -25,4 +44,5 @@
     {{ .Content }}
   </div>
 </article>
+{{ end }}
 {{ end }}

--- a/ZeroHunger.ai/themes/zerohunger/layouts/index.html
+++ b/ZeroHunger.ai/themes/zerohunger/layouts/index.html
@@ -1,20 +1,10 @@
 {{ define "main" }}
 
 {{/* ── HERO ─────────────────────────────────────────────────────────── */}}
-{{/* Static fallback always available; Hugo pipeline enhances with WebP if possible */}}
-{{ $heroBg := "/images/hero-tegucigalpa-sunset.jpg" }}
-{{ $heroSrcset := "" }}
-{{ $hero := resources.Get "images/projects/honduras/hero-tegucigalpa-sunset.jpg" }}
-{{ if $hero }}
-{{ $hero1920 := $hero.Resize "1920x webp" }}
-{{ $heroFallback := $hero.Resize "1920x jpg" }}
-{{ $heroBg = $heroFallback.RelPermalink }}
-{{ $heroSrcset = $hero1920.RelPermalink }}
-{{ end }}
+{{ $heroBg := "/images/workshop.jpg" }}
 <section class="zh-hero" style="background-image:url({{ $heroBg }})">
   <picture style="position:absolute;inset:0;z-index:0">
-    {{ if $heroSrcset }}<source srcset="{{ $heroSrcset }}" type="image/webp">{{ end }}
-    <img src="{{ $heroBg }}" alt="Tegucigalpa, Honduras — where we work"
+    <img src="{{ $heroBg }}" alt="ZeroHunger.ai team workshop"
          style="width:100%;height:100%;object-fit:cover;display:block" loading="eager">
   </picture>
   <div class="zh-hero__inner">


### PR DESCRIPTION
## Summary

- **Homepage**: replaced `hero-tegucigalpa-sunset.jpg` (Hugo resource pipeline) with `/images/workshop.jpg` from static — removes build-time pipeline dependency, matches prod
- **About page**: changed `featured_image` from relative `../images/...` path (which `resources.Get` silently ignores) to `/images/workshop.jpg`
- **`single.html`**: added static-path branch — when `featured_image` starts with `/`, renders a full-bleed `zh-hero` section instead of skipping the image silently

## Root cause

`resources.Get` cannot resolve `../images/...` relative paths or absolute `/images/...` static paths — both return nil and the `{{ if $img }}` block is skipped. The homepage hero also depended on the Hugo resource pipeline for the tegucigalpa image, which appears not to render in the dev build.

## Test plan

- [ ] Dev deploy (CI auto-triggers on push to develop after merge)
- [ ] `/` — full-width workshop.jpg hero visible behind overlay
- [ ] `/about/` — full-width workshop.jpg hero visible with page title overlaid
- [ ] Compare page size on dev: should be >372 KB now that image loads
- [ ] No regression on project pages (use resources.Get path — unaffected)

Closes OPT-321. Unblocks [OPT-316] QA sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)