### PR TITLE
content(OPT-333): add MMCY sequa ETH-1013 training advisor article and project page

### DIFF
--- a/ZeroHunger.ai/content/en/post/mmcy-sequa-sme-training-advisor-ethiopia.md
+++ b/ZeroHunger.ai/content/en/post/mmcy-sequa-sme-training-advisor-ethiopia.md
@@ -1,0 +1,116 @@
+---
+title: "Embedded Training Advisory for a BPO Company in Ethiopia: Scaling Talent Development Through Agile Capacity Building"
+date: 2026-05-18T10:00:00+02:00
+tags: ["ethiopia", "capacity-building", "BPO", "agile", "talent-development", "sequa", "international-development", "training"]
+featured_image: "images/projects/ethiopia/IMG_20240523_124517.jpg"
+description: "How an embedded SME Training Advisor helped an Ethiopian BPO company redesign its talent pipeline, replace an ineffective bootcamp, and introduce agile capacity building over a 10-month engagement."
+translationKey: "case-mmcy-sequa-training-advisor"
+---
+
+A well-established Ethiopian BPO and remote team augmentation company with over 15 years of experience and approximately 70 software professionals was hitting a growth ceiling. The company delivered software development, event support, IT helpdesk, and sales representation services to international clients, but a shortage of experienced IT professionals was preventing it from scaling existing teams and onboarding new customers.
+
+The company's TechUp Bootcamp, designed to train and place junior developers, had a placement rate of just 15% (3 out of 20 candidates hired, all of whom were already highly qualified before entering the program). The bootcamp conflated assessment, onboarding, and upskilling into a single program, diluting the effectiveness of each. Meanwhile, an informal policy of targeting 100% billable hours left no capacity for strategic talent development, internal process improvement, or employee-driven growth initiatives.
+
+Through [sequa gGmbH](https://www.sequa.de/), a German organization supporting private sector development, ZeroHunger.ai founder Markus Matiaschek was contracted as SME Training Advisor under the ETH-1013 program for up to 20 working days over a 10-month engagement period (June 2024 -- April 2025).
+
+## Approach
+
+The engagement followed a three-phase methodology designed for embedded advisory work where lasting change depends on internal ownership rather than external execution.
+
+### Phase 1: Leadership Alignment and Strategic Assessment
+
+Before any workshops or interventions, the advisor conducted a remote discovery phase to assess the company's growth bottleneck, talent pipeline, and organizational dynamics. This included reviewing existing KPIs, recruitment funnel data, and ISO certification processes already underway.
+
+Key findings from the initial assessment:
+
+- **Conflicting bootcamp purposes.** The TechUp Bootcamp simultaneously served as assessment center, general tech education, and job placement pipeline, weakening all three functions.
+- **Curriculum-reality gap.** While writing code was the primary focus of the bootcamp (and university education), it represents roughly 10% of a working software engineer's job. Debugging, testing, deployment, codebase comprehension, professional teamwork, and client communication were not systematically addressed.
+- **Agile terminology without practice.** Leadership and employees used agile vocabulary but lacked practical understanding of how to implement and benefit from agile methodologies in their daily work.
+- **No bench management policy.** When placements ended, employees faced inconsistent treatment. Some remained on internal projects indefinitely while others did not receive the same opportunity, creating inequity and disengagement.
+- **Organizational overload.** Senior staff held multiple roles simultaneously (project manager, trainer, solution architect, senior developer), creating bottlenecks and preventing effective delegation or team growth.
+
+### Phase 2: Frameworks and Interventions
+
+Based on the assessment, the advisor designed and introduced three interconnected frameworks:
+
+**1. Three-Stage Talent Pipeline (replacing the monolithic bootcamp)**
+
+Rather than running candidates through a single bootcamp that tries to do everything, the recommendation was to split the process into three focused stages:
+
+- **Assessment Center:** Evaluate candidates efficiently against specific client project requirements and company best practices before investing training resources. This replaces the ongoing assessment embedded in the old bootcamp that wasted mentor time.
+- **Focused Onboarding:** A streamlined process exclusively covering company standards, tools, processes, and professional practices to achieve immediate baseline productivity.
+- **Upskilling and Placement Pool Team:** A self-organized team of up to 9 members (aligned with Scrum team size) combining new talent and benched employees. The team works on non-critical but real contributions to internal and customer projects, with juniors learning from senior peers while seniors develop leadership and mentorship skills.
+
+**2. TechUp Bootcamp 2.0 Curriculum**
+
+For cases where a structured bootcamp format was preferred, the advisor designed a 4--6 week Agile-based curriculum that addresses the gaps identified in the existing program:
+
+- **Week 1:** Professional and Agile foundations, version control, soft skills, individual development plan creation, and kickoff of a real internal software project.
+- **Weeks 2--3:** Full Agile sprint execution with daily standups, sprint planning, retrospectives, peer programming, automated testing, CI/CD workflows, and introduction to AI-powered development tools.
+- **Week 4:** Project completion, MVP deployment, mock interviews, client-facing skills training, and final sprint review with leadership.
+
+Key difference from the old bootcamp: participants work as a self-organized Agile team on real internal projects from day one rather than completing individual theoretical exercises. Mentorship comes through structured sprint reviews rather than constant (and inefficient) daily supervision.
+
+**3. Agile Upskilling Process**
+
+A formal Scrum-based upskilling process was designed and documented (aligned with the company's ongoing ISO 9001 certification), including:
+
+- Defined roles: Product Owner (Director of Learning and Development), Scrum Master (experienced agile coach), Dev Team Mentors, and Team Links connecting to placement teams.
+- Sprint-based learning cycles with planning, daily standups, retrospectives, and documented outcomes.
+- Individual Development Plans (IDPs) for each team member, replacing the one-size-fits-all approach.
+- Clear escalation paths from bootcamp graduate to upskilling team member to client placement.
+
+### Phase 3: Growth Strategy and Organizational Recommendations
+
+Beyond the immediate talent pipeline work, the assessment surfaced strategic organizational challenges:
+
+- **Growth requires demand-side action.** The company's bench was not growing because leadership lacked urgency for scaling. Without proactive business development and domain expert involvement in sales, the demand to absorb trained talent did not materialize.
+- **Domain experts need ownership.** Senior developers and team leads should be empowered as owners of their respective service lines, with responsibility for team building, upselling, and client relationship depth, rather than operating purely as individual contributors placed at client sites.
+- **AI disruption preparedness.** The assessment flagged exponentially increasing risks from emerging agentic AI systems in call-center operations, sales representation, and software engineering, recommending that the company position itself as a leader in AI-augmented professional services rather than being disrupted by them.
+
+Objective and Key Results (OKRs) were collaboratively developed to drive measurable outcomes:
+
+| Objective | Key Result | Target |
+|---|---|---|
+| Effective Junior Developer Training and Placement | Graduates onboarded | 20 by Jan 2025 |
+| | Trainees actively contributing to customer teams | 20 by June 2025 |
+| | Trainee satisfaction score | 85%+ |
+| Enhanced Team Efficiency and Customer Satisfaction | Retrospectives in all dev teams | 100% by Feb 2025 |
+| | Developer productivity feedback mechanisms | Established by April 2025 |
+| | Customer NPS improvement | +10 points by March 2025 |
+
+Staff growth projections were modeled across attrition scenarios, showing a path from 70 hired software professionals in 2024/25 to 202 by 2027/28 under a realistic 20% attrition rate.
+
+## Outcome
+
+The engagement produced a comprehensive assessment report, a redesigned bootcamp curriculum, a documented upskilling process (ISO-aligned), OKR framework, staff projections model, and strategic recommendations covering talent development, bench management, and organizational agility.
+
+The core recommendations were:
+
+1. **Replace or fundamentally transform the TechUp Bootcamp** to separate assessment from training, introduce team-based learning, and align with real-world engineering practices.
+2. **Establish an Upskilling and Placement Pool Team** to productively integrate benched employees and new graduates while reducing time-to-placement.
+3. **Create transparent bench management policies** aligned with industry standards (70--85% utilization targets rather than informal 100%).
+4. **Invest in internal agile coaching capability** to make process improvements self-sustaining rather than dependent on external consultants.
+5. **Empower domain experts as service line owners** to drive bottom-up growth through client relationships, team building, and proactive business development.
+
+Implementation of these recommendations requires sustained internal leadership commitment. The advisor proposed a final retrospective involving all stakeholders (sequa, the partner company, and other contracted experts) to capture lessons learned and improve the effectiveness of similar future capacity building initiatives in the Ethiopian tech sector.
+
+## Transferable Lessons
+
+This engagement illustrates several patterns that apply broadly to capacity building advisory in emerging-market tech companies:
+
+**Embedded advisory requires internal ownership.** An external consultant with 20 working days cannot drive organizational change alone. The advisory must design frameworks and create urgency, but the partner organization must provide active project leadership, stakeholder access, and willingness to experiment with new approaches.
+
+**Bootcamps fail when they conflate assessment and training.** Organizations that use the same program to evaluate candidates and develop their skills end up doing neither well. Separating these functions dramatically improves the efficiency of both mentors and trainees.
+
+**Zero non-billable hours is a growth trap.** Maximizing short-term billable utilization eliminates the strategic capacity needed for talent development, process improvement, and proactive business capture. Industry-standard utilization targets of 70--85% exist for a reason.
+
+**Agile adoption requires genuine understanding, not terminology.** Organizations that adopt Scrum vocabulary without understanding the purpose of retrospectives, sprint reviews, and timeboxing cannot realize the benefits of agile practices. Leadership must deeply engage with and champion the methodology before it can cascade through the organization.
+
+**On-the-job training outperforms simulation.** Trainees learn faster and become placement-ready sooner when working on real (if non-critical) projects alongside experienced colleagues than when completing artificial exercises in isolation.
+
+---
+
+*ZeroHunger.ai provides embedded SME advisory for international development organizations and their private sector partners. Our capacity building engagements focus on making improvements self-sustaining through internal ownership, agile methodologies, and practical frameworks grounded in industry best practices.*
+
+*[View the MMCY project page](/projects/mmcy/) | [AI Consulting Models](/articles/ai-consulting-models/) | [AI Implementation Process](/articles/ai-implementation-process/)*

--- a/ZeroHunger.ai/content/en/projects/mmcy/index.md
+++ b/ZeroHunger.ai/content/en/projects/mmcy/index.md
@@ -1,0 +1,64 @@
+---
+title: "Scaling Talent Development at an Ethiopian BPO: Embedded SME Training Advisory"
+description: "How ZeroHunger.ai served as embedded SME Training Advisor for an Ethiopian BPO company under the sequa ETH-1013 program, redesigning its talent pipeline and introducing agile capacity building."
+date: 2026-05-18T10:00:00+02:00
+country: "🇪🇹 Ethiopia"
+client: "sequa gGmbH"
+year: "2024–2025"
+featured_image: "images/projects/ethiopia/IMG_20240523_124517.jpg"
+tags: ["ethiopia", "capacity-building", "BPO", "agile", "talent-development", "sequa", "training"]
+stats:
+  - { label: "Engagement duration", value: "10 months" }
+  - { label: "Advisory days", value: "20" }
+  - { label: "Staff (2024/25)", value: "70" }
+  - { label: "Growth target (2028)", value: "202" }
+---
+
+Between June 2024 and April 2025, ZeroHunger.ai founder Markus Matiaschek served as embedded SME Training Advisor to a well-established Ethiopian BPO and remote team augmentation company under sequa gGmbH's ETH-1013 program. The engagement addressed a critical growth bottleneck: a talent pipeline that was failing to produce placement-ready junior developers despite significant investment in training.
+
+## The Challenge
+
+The company — with over 15 years of experience and approximately 70 software professionals — delivered software development, event support, IT helpdesk, and sales representation services to international clients. A shortage of experienced IT professionals was preventing it from scaling existing teams and onboarding new customers.
+
+The core problem was structural. The company's TechUp Bootcamp had a placement rate of just 15%: 3 out of 20 candidates hired, all of whom were already highly qualified before entering the program. The bootcamp conflated three distinct functions — assessment, onboarding, and upskilling — into a single program, weakening all three. An informal 100% billable hours policy left no organizational capacity for the talent development work the company urgently needed.
+
+## Our Approach
+
+The advisory followed three phases over the 10-month engagement:
+
+**Phase 1 — Assessment:** Remote discovery covering growth bottlenecks, recruitment funnel data, existing KPIs, and ISO certification processes. The assessment surfaced five structural gaps: conflicting bootcamp purposes, a curriculum-reality gap (code writing is ~10% of a software engineer's job), agile vocabulary without agile practice, absent bench management policies, and organizational overload on senior staff.
+
+**Phase 2 — Framework Design:** Three interconnected frameworks were designed and documented:
+
+- **Three-Stage Talent Pipeline** separating assessment, focused onboarding, and a Scrum-sized upskilling team from the monolithic bootcamp
+- **TechUp Bootcamp 2.0** — a 4–6 week agile curriculum built around real internal projects, peer programming, CI/CD, and structured sprint reviews
+- **ISO-aligned Agile Upskilling Process** with defined roles, Individual Development Plans, and clear escalation paths from graduate to client placement
+
+**Phase 3 — Growth Strategy:** Beyond the immediate talent pipeline, the engagement addressed demand-side constraints, domain expert empowerment as service line owners, and AI disruption preparedness — positioning the company for leadership in AI-augmented professional services rather than commoditization.
+
+## What We Delivered
+
+| Deliverable | Description |
+|---|---|
+| Assessment report | Recruitment funnel analysis, bootcamp diagnosis, org capacity mapping |
+| TechUp Bootcamp 2.0 curriculum | 4–6 week agile-based program replacing the monolithic bootcamp |
+| Agile Upskilling Process | ISO 9001-aligned Scrum process with documented roles and IDPs |
+| OKR framework | Measurable objectives for training placement, team efficiency, and customer satisfaction |
+| Staff growth model | Projections from 70 (2024/25) to 202 (2027/28) across attrition scenarios |
+| Strategic recommendations | Bench management policy, domain expert empowerment, AI readiness roadmap |
+
+## Key Lessons
+
+**Bootcamps fail when they conflate assessment and training.** Separating candidate evaluation from development dramatically improves mentor efficiency and trainee placement rates.
+
+**Zero non-billable hours is a growth trap.** Industry-standard utilization targets of 70–85% exist because organizations need slack capacity for talent development, process improvement, and proactive business capture.
+
+**Agile adoption requires genuine understanding, not terminology.** Leadership must deeply engage with and champion the methodology before it can cascade through the organization.
+
+**On-the-job training outperforms simulation.** Trainees become placement-ready faster when working on real (if non-critical) projects alongside experienced colleagues than when completing artificial exercises in isolation.
+
+---
+
+*This engagement was conducted under sequa gGmbH's ETH-1013 program, supporting private sector development in Ethiopia. ZeroHunger.ai provided embedded SME Training Advisory services focused on talent pipeline redesign, agile capacity building, and organizational development.*
+
+*[Read the full case study](/post/mmcy-sequa-sme-training-advisor-ethiopia/)*


### PR DESCRIPTION
## Summary

- Synced `develop` with `main` (fast-forward: v4.3.0, v4.3.1 release commits)
- Added MMCY blog post at `content/en/post/mmcy-sequa-sme-training-advisor-ethiopia.md` — full article covering the 10-month ETH-1013 embedded advisory engagement
- Added MMCY project page at `content/en/projects/mmcy/index.md` — project summary with stats, deliverables table, and link to blog post
- `featured_image` uses existing Ethiopia photo: `images/projects/ethiopia/IMG_20240523_124517.jpg`

## Test plan

- [ ] Hugo CI build passes on develop
- [ ] Blog post renders at `/post/mmcy-sequa-sme-training-advisor-ethiopia/`
- [ ] Project page renders at `/projects/mmcy/`
- [ ] Featured image loads (existing Ethiopia asset)
- [ ] Internal links between blog post and project page resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)